### PR TITLE
Movement refactoring & lag reduced

### DIFF
--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -130,7 +130,6 @@ use const JSON_THROW_ON_ERROR;
  * This handler handles packets related to general gameplay.
  */
 class InGamePacketHandler extends PacketHandler{
-	private const MAX_FORM_RESPONSE_DEPTH = 2; //modal/simple will be 1, custom forms 2 - they will never contain anything other than string|int|float|bool|null
 
 	/** @var float */
 	protected $lastRightClickTime = 0.0;
@@ -953,12 +952,7 @@ class InGamePacketHandler extends PacketHandler{
 			//TODO: make APIs for this to allow plugins to use this information
 			return $this->player->onFormSubmit($packet->formId, null);
 		}elseif($packet->formData !== null){
-			try{
-				$responseData = json_decode($packet->formData, true, self::MAX_FORM_RESPONSE_DEPTH, JSON_THROW_ON_ERROR);
-			}catch(\JsonException $e){
-				throw PacketHandlingException::wrap($e, "Failed to decode form response data");
-			}
-			return $this->player->onFormSubmit($packet->formId, $responseData);
+			return $this->player->onFormSubmit($packet->formId, $packet->formData);
 		}else{
 			throw new PacketHandlingException("Expected either formData or cancelReason to be set in ModalFormResponsePacket");
 		}

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -109,6 +109,7 @@ use pocketmine\utils\Limits;
 use pocketmine\utils\TextFormat;
 use pocketmine\utils\Utils;
 use pocketmine\world\format\Chunk;
+use pocketmine\world\Position;
 use function array_push;
 use function count;
 use function fmod;
@@ -200,22 +201,6 @@ class InGamePacketHandler extends PacketHandler{
 			$this->player->setRotation($yaw, $pitch);
 		}
 
-		$hasMoved = $this->lastPlayerAuthInputPosition === null || !$this->lastPlayerAuthInputPosition->equals($rawPos);
-		$newPos = $rawPos->round(4)->subtract(0, 1.62, 0);
-
-		if($this->forceMoveSync && $hasMoved){
-			$curPos = $this->player->getLocation();
-
-			if($newPos->distanceSquared($curPos) > 1){  //Tolerate up to 1 block to avoid problems with client-sided physics when spawning in blocks
-				$this->session->getLogger()->debug("Got outdated pre-teleport movement, received " . $newPos . ", expected " . $curPos);
-				//Still getting movements from before teleport, ignore them
-				return true;
-			}
-
-			// Once we get a movement within a reasonable distance, treat it as a teleport ACK and remove position lock
-			$this->forceMoveSync = false;
-		}
-
 		$inputFlags = $packet->getInputFlags();
 		if($inputFlags !== $this->lastPlayerAuthInputFlags){
 			$this->lastPlayerAuthInputFlags = $inputFlags;
@@ -240,12 +225,7 @@ class InGamePacketHandler extends PacketHandler{
 			}
 		}
 
-		if(!$this->forceMoveSync && $hasMoved){
-			$this->lastPlayerAuthInputPosition = $rawPos;
-			//TODO: this packet has WAYYYYY more useful information that we're not using
-			$this->player->handleMovement($newPos);
-		}
-
+		$this->processMovements($packet->getPosition(), fixHeadOffset: true);
 		$packetHandled = true;
 
 		$blockActions = $packet->getBlockActions();
@@ -292,6 +272,41 @@ class InGamePacketHandler extends PacketHandler{
 		}
 
 		return $packetHandled;
+	}
+
+	/**
+	 * @param Position $position
+	 * @param bool     $fixHeadOffset $
+	 *
+	 * @return void
+	 */
+	private function processMovements(Vector3 $position, bool $fixHeadOffset) : void{
+		$hasMoved = $this->lastPlayerAuthInputPosition === null || !$this->lastPlayerAuthInputPosition->equals($position);
+
+		$newPos = $position;
+		if($fixHeadOffset) {
+			$headOffset = $this->player->isSneaking() ? 1.54 : 1.62; //TODO: this is a hack, the client doesn't send the head offset, so we assume it's always 1.62 unless sneaking
+			$newPos = $position->subtract(0, $headOffset, 0); //the client sends the head position, but we need the feet position for movement handling
+		}
+
+		if($this->forceMoveSync && $hasMoved){
+			$curPos = $this->player->getLocation();
+
+			if($newPos->distanceSquared($curPos) > 1){  //Tolerate up to 1 block to avoid problems with client-sided physics when spawning in blocks
+				$this->session->getLogger()->debug("Got outdated pre-teleport movement, received " . $newPos . ", expected " . $curPos);
+				//Still getting movements from before teleport, ignore them
+				return;
+			}
+
+			// Once we get a movement within a reasonable distance, treat it as a teleport ACK and remove position lock
+			$this->forceMoveSync = false;
+		}
+
+		if(!$this->forceMoveSync && $hasMoved){
+			$this->lastPlayerAuthInputPosition = $position;
+			//TODO: this packet has WAYYYYY more useful information that we're not using
+			$this->player->handleMovement($newPos);
+		}
 	}
 
 	public function handleActorEvent(ActorEventPacket $packet) : bool{
@@ -460,6 +475,13 @@ class InGamePacketHandler extends PacketHandler{
 	private function handleUseItemTransaction(UseItemTransactionData $data) : bool{
 		$this->player->selectHotbarSlot($data->getHotbarSlot());
 
+		// This hack allows you to throw, for example,
+		// an enderpearl or a snowball at the client's actual position,
+		// which is useful when the person is lagging or just playing.
+		//
+		// Do not use the anti-cheat feature to send incorrect positions,
+		// or if you do use it, perform advanced checks.
+		$this->processMovements($data->getPlayerPosition(), fixHeadOffset: false);
 		switch($data->getActionType()){
 			case UseItemTransactionData::ACTION_CLICK_BLOCK:
 				//TODO: start hack for client spam bug
@@ -545,6 +567,12 @@ class InGamePacketHandler extends PacketHandler{
 
 		$this->player->selectHotbarSlot($data->getHotbarSlot());
 
+		// The Hack reduces lag, making it much less noticeable when someone is lagging.
+		// This can improve gameplay in PvP and many other areas.
+		//
+		// Do not use the anti-cheat feature to send incorrect positions,
+		// or if you do use it, perform advanced checks.
+		$this->processMovements($data->getPlayerPosition(), fixHeadOffset: false);
 		switch($data->getActionType()){
 			case UseItemOnEntityTransactionData::ACTION_INTERACT:
 				$this->player->interactEntity($target, $data->getClickPosition());
@@ -560,6 +588,13 @@ class InGamePacketHandler extends PacketHandler{
 	private function handleReleaseItemTransaction(ReleaseItemTransactionData $data) : bool{
 		$this->player->selectHotbarSlot($data->getHotbarSlot());
 
+		// This hack allows you to throw, for example,
+		// an enderpearl or a snowball at the client's actual position,
+		// which is useful when the person is lagging or just playing.
+		//
+		// Do not use the anti-cheat feature to send incorrect positions,
+		// or if you do use it, perform advanced checks.
+		$this->processMovements($data->getHeadPosition(), fixHeadOffset: true);
 		if($data->getActionType() == ReleaseItemTransactionData::ACTION_RELEASE){
 			$this->player->releaseHeldItem();
 			return true;

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -112,6 +112,7 @@ use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataCollection;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataFlags;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataProperties;
 use pocketmine\network\mcpe\protocol\types\entity\PlayerMetadataFlags;
+use pocketmine\network\PacketHandlingException;
 use pocketmine\permission\DefaultPermissionNames;
 use pocketmine\permission\DefaultPermissions;
 use pocketmine\permission\PermissibleBase;
@@ -162,6 +163,8 @@ use const PHP_INT_MAX;
  */
 class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	use PermissibleDelegateTrait;
+
+	private const MAX_FORM_RESPONSE_DEPTH = 2; //modal/simple will be 1, custom forms 2 - they will never contain anything other than string|int|float|bool|null
 
 	private const MOVES_PER_TICK = 2;
 	private const MOVE_BACKLOG_SIZE = 100 * self::MOVES_PER_TICK; //100 ticks backlog (5 seconds)
@@ -2102,12 +2105,21 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	}
 
 	/**
-	 * @param mixed $responseData
+	 * @param int         $formId
+	 * @param string|null $data
+	 *
+	 * @return bool
 	 */
-	public function onFormSubmit(int $formId, $responseData) : bool{
+	public function onFormSubmit(int $formId, ?string $data) : bool{
 		if(!isset($this->forms[$formId])){
 			$this->logger->debug("Got unexpected response for form $formId");
 			return false;
+		}
+
+		try{
+			$responseData = json_decode($data, true, self::MAX_FORM_RESPONSE_DEPTH, JSON_THROW_ON_ERROR);
+		}catch(\JsonException $e){
+			throw PacketHandlingException::wrap($e, "Failed to decode form response data");
 		}
 
 		try{
@@ -2115,6 +2127,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		}catch(FormValidationException $e){
 			$this->logger->critical("Failed to validate form " . get_class($this->forms[$formId]) . ": " . $e->getMessage());
 			$this->logger->logException($e);
+		} catch(\Exception $exception) {
+			throw PacketHandlingException::wrap($exception, "Failed to handle form response for form " . get_class($this->forms[$formId]) . " with ID $formId");
 		}finally{
 			unset($this->forms[$formId]);
 		}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1271,11 +1271,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	}
 
 	private function actuallyHandleMovement(Vector3 $newPos) : void{
-		$this->moveRateLimit--;
-		if($this->moveRateLimit < 0){
-			return;
-		}
-
 		$oldPos = $this->location;
 		$distanceSquared = $newPos->distanceSquared($oldPos);
 
@@ -1318,12 +1313,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	 * Fires movement events and synchronizes player movement, every tick.
 	 */
 	protected function processMostRecentMovements() : void{
-		$now = microtime(true);
-		$multiplier = $this->lastMovementProcess !== null ? ($now - $this->lastMovementProcess) * 20 : 1;
-		$exceededRateLimit = $this->moveRateLimit < 0;
-		$this->moveRateLimit = min(self::MOVE_BACKLOG_SIZE, max(0, $this->moveRateLimit) + self::MOVES_PER_TICK * $multiplier);
-		$this->lastMovementProcess = $now;
-
 		$from = clone $this->lastLocation;
 		$to = clone $this->location;
 
@@ -1361,11 +1350,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 					$this->nextChunkOrderRun = 20;
 				}
 			}
-		}
-
-		if($exceededRateLimit){ //client and server positions will be out of sync if this happens
-			$this->logger->debug("Exceeded movement rate limit, forcing to last accepted position");
-			$this->sendPosition($this->location, $this->location->getYaw(), $this->location->getPitch(), MovePlayerPacket::MODE_RESET);
 		}
 	}
 


### PR DESCRIPTION
In the case of an anti-cheat system, adding movement checks before those of PlayerAuthInput, the person could send teleportation commands for whatever they teleported. Normally, between these two position systems, there is no problem; you just need to check the reliability of the positions, but since the behavior and distance are the same, it would be pointless to do so.

And no cheat client performs this spoof or anything else because it is completely detectable.
I therefore advise you to add a check.