### PR TITLE
Add timeline profiling during timings

### DIFF
--- a/generated/YmlServerProperties.php
+++ b/generated/YmlServerProperties.php
@@ -100,6 +100,7 @@ final class YmlServerProperties{
 	public const SETTINGS_ASYNC_WORKERS = 'settings.async-workers';
 	public const SETTINGS_ENABLE_DEV_BUILDS = 'settings.enable-dev-builds';
 	public const SETTINGS_ENABLE_PROFILING = 'settings.enable-profiling';
+	public const SETTINGS_ENABLE_TIMELINE_PROFILING = 'settings.enable-timeline-profiling';
 	public const SETTINGS_FORCE_LANGUAGE = 'settings.force-language';
 	public const SETTINGS_PROFILE_REPORT_TRIGGER = 'settings.profile-report-trigger';
 	public const SETTINGS_QUERY_PLUGINS = 'settings.query-plugins';

--- a/resources/pocketmine.yml
+++ b/resources/pocketmine.yml
@@ -11,6 +11,8 @@ settings:
   query-plugins: true
   #Enable plugin and core profiling by default
   enable-profiling: false
+  #Enable timeline profiling during profiling. This adds more detailed information about where time is spent during ticks, but has a higher performance cost.
+  enable-timeline-profiling: false
   #Will only add results when tick measurement is below or equal to given value (default 20)
   profile-report-trigger: 20
   #Number of AsyncTask workers.

--- a/src/Server.php
+++ b/src/Server.php
@@ -102,6 +102,7 @@ use pocketmine\thread\ThreadCrashException;
 use pocketmine\thread\ThreadSafeClassLoader;
 use pocketmine\timings\Timings;
 use pocketmine\timings\TimingsHandler;
+use pocketmine\timings\TimingsTimelineRegistry;
 use pocketmine\updater\UpdateChecker;
 use pocketmine\utils\AssumptionFailedError;
 use pocketmine\utils\BroadcastLoggerForwarder;
@@ -952,6 +953,7 @@ class Server{
 			}
 
 			TimingsHandler::setEnabled($this->configGroup->getPropertyBool(Yml::SETTINGS_ENABLE_PROFILING, false));
+			TimingsHandler::setTimelineEnabled($this->configGroup->getPropertyBool(Yml::SETTINGS_ENABLE_TIMELINE_PROFILING, false));
 			$this->profilingTickRate = $this->configGroup->getPropertyInt(Yml::SETTINGS_PROFILE_REPORT_TRIGGER, self::TARGET_TICKS_PER_SECOND);
 
 			$this->asyncPool = new AsyncPool($poolSize, max(-1, $this->configGroup->getPropertyInt(Yml::MEMORY_ASYNC_WORKER_HARD_LIMIT, 256)), $this->autoloader, $this->logger, $this->tickSleeper);
@@ -1928,6 +1930,8 @@ class Server{
 			return;
 		}
 
+		TimingsTimelineRegistry::endTick();
+		TimingsTimelineRegistry::newTick($this->tickCounter + 1, null);
 		Timings::$serverTick->startTiming();
 
 		++$this->tickCounter;
@@ -1995,6 +1999,7 @@ class Server{
 		$this->currentUse = min(1, $totalTickTimeSeconds / self::TARGET_SECONDS_PER_TICK);
 
 		TimingsHandler::tick($this->currentTPS <= $this->profilingTickRate);
+		TimingsTimelineRegistry::endTick();
 
 		$idx = $this->tickCounter % self::TARGET_TICKS_PER_SECOND;
 		$this->tickAverage[$idx] = $this->currentTPS;
@@ -2006,5 +2011,7 @@ class Server{
 		}else{
 			$this->nextTick += self::TARGET_SECONDS_PER_TICK;
 		}
+
+		TimingsTimelineRegistry::newTick($this->tickCounter + 1, $this->tickCounter);
 	}
 }

--- a/src/timings/TimingsHandler.php
+++ b/src/timings/TimingsHandler.php
@@ -29,6 +29,7 @@ use pocketmine\promise\Promise;
 use pocketmine\promise\PromiseResolver;
 use pocketmine\Server;
 use pocketmine\utils\AssumptionFailedError;
+use pocketmine\utils\BinaryStream;
 use pocketmine\utils\ObjectSet;
 use pocketmine\utils\Utils;
 use Symfony\Component\Filesystem\Path;
@@ -52,6 +53,7 @@ class TimingsHandler{
 	private const FORMAT_VERSION = 3; //thread timings collection
 
 	private static bool $enabled = false;
+	private static bool $timelineEnabled = false;
 	private static int $timingStart = 0;
 
 	/** @phpstan-var ObjectSet<\Closure(bool $enable) : void> */
@@ -128,6 +130,15 @@ class TimingsHandler{
 			}
 		}
 
+		$result[] = "###TIMELINE###";
+		$stream = new BinaryStream();
+		foreach(TimingsTimelineRegistry::getArchivedTimelines() as $timeline){
+			$stream->putByte(0);
+			$stream->put($timeline);
+		}
+		$result[] = $stream->getBuffer();
+		$result[] = "###TIMELINE END###";
+
 		return $result;
 	}
 
@@ -202,6 +213,10 @@ class TimingsHandler{
 		return self::$enabled;
 	}
 
+	public static function isTimelineEnabled() : bool{
+		return self::$timelineEnabled;
+	}
+
 	public static function setEnabled(bool $enable = true) : void{
 		if($enable === self::$enabled){
 			return;
@@ -213,6 +228,10 @@ class TimingsHandler{
 				$callback($enable);
 			}
 		}
+	}
+
+	public static function setTimelineEnabled(bool $enable = true) : void{
+		self::$timelineEnabled = $enable;
 	}
 
 	public static function getStartTime() : float{

--- a/src/timings/TimingsRecord.php
+++ b/src/timings/TimingsRecord.php
@@ -33,7 +33,7 @@ use function spl_object_id;
  * This record will live until the end of the current timings session, even if its handler goes out of scope. This
  * ensures that timings collected by destroyed timers are still shown in the final report.
  */
-final class TimingsRecord{
+final class TimingsRecord implements \Stringable{
 	/**
 	 * @var self[]
 	 * @phpstan-var array<int, self>
@@ -128,6 +128,7 @@ final class TimingsRecord{
 	public function startTiming(int $now) : void{
 		$this->start = $now;
 		self::$currentRecord = $this;
+		TimingsTimelineRegistry::startEntry($this);
 	}
 
 	public function stopTiming(int $now) : void{
@@ -143,6 +144,7 @@ final class TimingsRecord{
 			throw new AssumptionFailedError("stopTiming() called on a non-current timer");
 		}
 		self::$currentRecord = $this->parentRecord;
+		TimingsTimelineRegistry::endEntry($this);
 		$diff = $now - $this->start;
 		$this->totalTime += $diff;
 		$this->curTickTotal += $diff;
@@ -156,5 +158,9 @@ final class TimingsRecord{
 
 	public static function getCurrentRecord() : ?self{
 		return self::$currentRecord;
+	}
+
+	public function __toString() : string{
+		return "TimingsRecord(timer={$this->getName()}, count={$this->count}, totalTime={$this->totalTime}ns, violations={$this->violations}, ticksActive={$this->ticksActive})";
 	}
 }

--- a/src/timings/TimingsTimeline.php
+++ b/src/timings/TimingsTimeline.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\timings;
+
+use function hrtime;
+
+/**
+ * Tracks the timeline of all timings executions for a given tick, maintaining hierarchy
+ */
+final class TimingsTimeline{
+	/** @var TimingsTimelineEntry[] */
+	private array $rootEntries = [];
+
+	/** @var TimingsTimelineEntry[] */
+	private array $stack = [];
+
+	private int $nextDepth = 0;
+	private readonly int $tickStartTime;
+	/** @var array<int, TimingsTimelineEntry[]> */
+	private array $pendingChildren = [];
+
+	/**
+	 * @param int $previousTick Previous tick represent a mid-tick timeline
+	 */
+	public function __construct(
+		public readonly int $tick,
+		public readonly ?int $previousTick
+	){
+		$this->tickStartTime = hrtime(true);
+	}
+
+	/**
+	 * Record the start of a timer execution
+	 */
+	public function startEntry(TimingsRecord $record) : void{
+		$depth = $this->nextDepth;
+		$this->stack[$depth] = new TimingsTimelineEntry(
+			tick: $this->tick,
+			record: $record,
+			startTime: hrtime(true),
+			endTime: 0,
+			depth: $depth
+		);
+		//\GlobalLogger::get()->debug("Starting timer '{$record->getName()}' (ID: {$record->getTimerId()} at depth $depth for tick {$this->tick}");
+		$this->nextDepth++;
+	}
+
+	/**
+	 * Record the end of a timer execution
+	 */
+	public function endEntry(TimingsRecord $record) : void{
+		if($this->nextDepth === 0){
+			\GlobalLogger::get()->warning("Attempted to end timing entry but stack is empty for tick {$this->tick}");
+			return; // Safety check
+		}
+
+		$this->nextDepth--;
+		$depth = $this->nextDepth;
+		$entry = $this->stack[$depth];
+		$endTime = hrtime(true);
+
+		if ($entry->record !== $record) {
+			\GlobalLogger::get()->warning("Mismatched timing entry end: expected '{$entry->record->getName()}' (ID: {$entry->record->getTimerId()}) but got '{$record->getName()}' (ID: {$record->getTimerId()}) at depth $depth for tick {$this->tick}");
+			return; // Safety check
+		}
+
+		// Create the completed entry with actual end time
+		$completedEntry = new TimingsTimelineEntry(
+			tick: $this->tick,
+			record: $record,
+			startTime: $entry->startTime,
+			endTime: $endTime,
+			depth: $depth,
+			children: $this->pendingChildren[$depth] ?? []
+		);
+
+		unset($this->stack[$depth]);
+		unset($this->pendingChildren[$depth]);
+
+		if($this->nextDepth === 0){
+			// This is a root entry
+			$this->rootEntries[] = $completedEntry;
+			//\GlobalLogger::get()->debug("Completed root timer '{$entry->record}' at depth {$entry->depth} for tick {$this->tick}");
+		}else{
+			// This entry will be added as a child by its parent when it ends
+			$this->pendingChildren[$depth - 1][] = $completedEntry;
+			//\GlobalLogger::get()->debug("Completed timer '{$entry->record}' at depth {$entry->depth} for tick {$this->tick} (attached to parent)");
+		}
+	}
+
+	/**
+	 * Get all root entries (top-level timers executed during this tick)
+	 * @return TimingsTimelineEntry[]
+	 */
+	public function getRootEntries() : array{
+		return $this->rootEntries;
+	}
+
+	/**
+	 * Get the tick start time
+	 */
+	public function getTickStartTime() : int{
+		return $this->tickStartTime;
+	}
+
+	/**
+	 * Get all entries in depth-first order
+	 * @return TimingsTimelineEntry[]
+	 */
+	public function getAllEntries() : array{
+		$entries = [];
+		foreach($this->rootEntries as $root){
+			$this->collectEntries($root, $entries);
+		}
+		return $entries;
+	}
+
+	/**
+	 * @param TimingsTimelineEntry[] $entries
+	 */
+	private function collectEntries(TimingsTimelineEntry $entry, array &$entries) : void{
+		$entries[] = $entry;
+		foreach($entry->children as $child){
+			$this->collectEntries($child, $entries);
+		}
+	}
+}
+

--- a/src/timings/TimingsTimelineEntry.php
+++ b/src/timings/TimingsTimelineEntry.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace pocketmine\timings;
+
+/**
+ * Represents a single execution event in the timeline hierarchy
+ */
+final readonly class TimingsTimelineEntry{
+	public function __construct(
+		public int $tick,
+		public TimingsRecord $record,
+		public int $startTime,
+		public int $endTime,
+		public int $depth,
+		/** @var TimingsTimelineEntry[] */
+		public array $children = []
+	){}
+
+	public function getDuration() : int{
+		return $this->endTime - $this->startTime;
+	}
+
+	public function getRelativeStartTime(int $tickStartTime) : int{
+		return $this->startTime - $tickStartTime;
+	}
+
+	public function getRelativeEndTime(int $tickStartTime) : int{
+		return $this->endTime - $tickStartTime;
+	}
+}

--- a/src/timings/TimingsTimelineRegistry.php
+++ b/src/timings/TimingsTimelineRegistry.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace pocketmine\timings;
+
+use pocketmine\utils\BinaryStream;
+
+final class TimingsTimelineRegistry{
+	private static ?TimingsTimeline $currentTimeline = null;
+	/** @var string[] */
+	private static array $archivedTimelines = [];
+
+	public static function newTick(int $tick, ?int $previousTick) : void {
+		if (TimingsHandler::isEnabled() && TimingsHandler::isTimelineEnabled()) {
+			//\GlobalLogger::get()->debug("Starting new timings timeline for tick $tick (previousTick: $previousTick)");
+			self::$currentTimeline = new TimingsTimeline($tick, $previousTick);
+		}
+	}
+
+	/** @return string[] */
+	public static function getArchivedTimelines() : array{
+		return self::$archivedTimelines;
+	}
+
+	public static function endTick() : void {
+		if (TimingsHandler::isEnabled() && TimingsHandler::isTimelineEnabled() && self::$currentTimeline !== null) {
+			//\GlobalLogger::get()->debug("Ending new timings timeline for current tick");
+			$stream = new BinaryStream();
+			$tickStartTime = self::$currentTimeline->getTickStartTime();
+			if (self::$currentTimeline->previousTick === null) {
+				$stream->putBool(false);
+				$stream->putLInt(self::$currentTimeline->tick);
+				$stream->putUnsignedVarLong($tickStartTime);
+			}else{
+				$stream->putBool(true);
+				$stream->putLInt(self::$currentTimeline->previousTick);
+				$stream->putLInt(self::$currentTimeline->tick);
+				$stream->putUnsignedVarLong($tickStartTime);
+			}
+			foreach(self::$currentTimeline->getAllEntries() as $entry){
+				$stream->putInt($entry->depth);
+				$stream->putInt($entry->record->getId());
+				$stream->putUnsignedVarLong($entry->getRelativeStartTime($tickStartTime));
+				$stream->putUnsignedVarLong($entry->getRelativeEndTime($tickStartTime));
+			}
+			self::$archivedTimelines[] = $stream->getBuffer();
+			self::$currentTimeline = null;
+		}
+	}
+
+	public static function startEntry(TimingsRecord $record) : void {
+		if (TimingsHandler::isEnabled() && TimingsHandler::isTimelineEnabled()) {
+			self::$currentTimeline?->startEntry($record);
+		}
+	}
+
+	public static function endEntry(TimingsRecord $record) : void {
+		if (TimingsHandler::isEnabled() && TimingsHandler::isTimelineEnabled()) {
+			self::$currentTimeline?->endEntry($record);
+		}
+	}
+}


### PR DESCRIPTION
This pull request adds a new timeline profiling feature to the server's timings system, allowing for more detailed profiling of where time is spent during each server tick. The feature is configurable, collects hierarchical timing data for each tick, and archives it for later analysis. The implementation introduces several new classes and integrates timeline tracking into the main server tick loop and timings handlers.


# Ne supporte pas encore les multi thread, collecte uniquement les timeline du thread pricnipal