### PR TITLE
Update to Minecraft Bedrock 1.26.30 (protocol 1001)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,12 @@
    "type": "project",
    "homepage": "https://pmmp.io",
    "license": "LGPL-3.0",
+   "repositories": [
+      {
+         "type": "vcs",
+         "url": "https://github.com/Plutonium-Mcpe/BedrockData.git"
+      }
+   ],
    "require": {
       "php": "^8.2",
       "php-64bit": "*",
@@ -35,9 +41,9 @@
       "adhocore/json-comment": "~1.2.0",
       "netresearch/jsonmapper": "~v5.0.0",
       "pocketmine/bedrock-block-upgrade-schema": "~5.2.0+bedrock-1.21.110",
-      "pocketmine/bedrock-data": "dev-bedrock-1.26.20",
-      "pocketmine/bedrock-item-upgrade-schema": "~1.16.0+bedrock-1.21.110",
-      "pocketmine/bedrock-protocol": "dev-bedrock-1.26.20",
+      "pocketmine/bedrock-data": "dev-bedrock-1.26.30",
+      "pocketmine/bedrock-item-upgrade-schema": "~1.17.0+bedrock-1.26.20",
+      "pocketmine/bedrock-protocol": "dev-bedrock-1.26.30#507a8df7c53b369f6e62aebd32e3dbaf609b4755",
       "pocketmine/binaryutils": "^0.2.1",
       "pocketmine/callback-validator": "~1.0.4",
       "pocketmine/color": "^0.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "500b69105f8138e0855551515ad0b506",
+    "content-hash": "201e135469ae18293556ac0581f60c74",
     "packages": [
         {
             "name": "adhocore/json-comment",
@@ -204,42 +204,40 @@
         },
         {
             "name": "pocketmine/bedrock-data",
-            "version": "dev-bedrock-1.26.20",
+            "version": "dev-bedrock-1.26.30",
             "source": {
                 "type": "git",
-                "url": "https://github.com/pmmp/BedrockData.git",
-                "reference": "588acca8a59ef403ceb64b57a18075426256bd68"
+                "url": "https://github.com/Plutonium-Mcpe/BedrockData.git",
+                "reference": "7e91146842837b2267a8e4d8bf8b8dab5e482970"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/BedrockData/zipball/588acca8a59ef403ceb64b57a18075426256bd68",
-                "reference": "588acca8a59ef403ceb64b57a18075426256bd68",
+                "url": "https://api.github.com/repos/Plutonium-Mcpe/BedrockData/zipball/7e91146842837b2267a8e4d8bf8b8dab5e482970",
+                "reference": "7e91146842837b2267a8e4d8bf8b8dab5e482970",
                 "shasum": ""
             },
             "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "CC0-1.0"
             ],
             "description": "Blobs of data generated from Minecraft: Bedrock Edition, used by PocketMine-MP",
             "support": {
-                "issues": "https://github.com/pmmp/BedrockData/issues",
-                "source": "https://github.com/pmmp/BedrockData/tree/bedrock-1.26.20"
+                "source": "https://github.com/Plutonium-Mcpe/BedrockData/tree/bedrock-1.26.30"
             },
-            "time": "2026-05-06T13:13:49+00:00"
+            "time": "2026-06-16T10:44:11+00:00"
         },
         {
             "name": "pocketmine/bedrock-item-upgrade-schema",
-            "version": "1.16.0",
+            "version": "1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/BedrockItemUpgradeSchema.git",
-                "reference": "8c48ceaa72d390e89c4dbff9542aa4dfa734057d"
+                "reference": "e19685d2e7e76eb7446115c556df34e5d627d072"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/BedrockItemUpgradeSchema/zipball/8c48ceaa72d390e89c4dbff9542aa4dfa734057d",
-                "reference": "8c48ceaa72d390e89c4dbff9542aa4dfa734057d",
+                "url": "https://api.github.com/repos/pmmp/BedrockItemUpgradeSchema/zipball/e19685d2e7e76eb7446115c556df34e5d627d072",
+                "reference": "e19685d2e7e76eb7446115c556df34e5d627d072",
                 "shasum": ""
             },
             "type": "library",
@@ -250,22 +248,22 @@
             "description": "JSON schemas for upgrading items found in older Minecraft: Bedrock world saves",
             "support": {
                 "issues": "https://github.com/pmmp/BedrockItemUpgradeSchema/issues",
-                "source": "https://github.com/pmmp/BedrockItemUpgradeSchema/tree/1.16.0"
+                "source": "https://github.com/pmmp/BedrockItemUpgradeSchema/tree/1.17.0"
             },
-            "time": "2025-10-02T13:22:32+00:00"
+            "time": "2026-05-06T13:12:04+00:00"
         },
         {
             "name": "pocketmine/bedrock-protocol",
-            "version": "dev-bedrock-1.26.20",
+            "version": "dev-bedrock-1.26.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/BedrockProtocol.git",
-                "reference": "300dc9ae37ca9a43f227afd655206a115bb61be9"
+                "reference": "507a8df7c53b369f6e62aebd32e3dbaf609b4755"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/300dc9ae37ca9a43f227afd655206a115bb61be9",
-                "reference": "300dc9ae37ca9a43f227afd655206a115bb61be9",
+                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/507a8df7c53b369f6e62aebd32e3dbaf609b4755",
+                "reference": "507a8df7c53b369f6e62aebd32e3dbaf609b4755",
                 "shasum": ""
             },
             "require": {
@@ -297,9 +295,9 @@
             "description": "An implementation of the Minecraft: Bedrock Edition protocol in PHP",
             "support": {
                 "issues": "https://github.com/pmmp/BedrockProtocol/issues",
-                "source": "https://github.com/pmmp/BedrockProtocol/tree/bedrock-1.26.20"
+                "source": "https://github.com/pmmp/BedrockProtocol/tree/bedrock-1.26.30"
             },
-            "time": "2026-05-06T14:03:50+00:00"
+            "time": "2026-06-16T11:12:56+00:00"
         },
         {
             "name": "pocketmine/binaryutils",

--- a/generated/data/bedrock/BedrockDataFiles.php
+++ b/generated/data/bedrock/BedrockDataFiles.php
@@ -43,7 +43,6 @@ final class BedrockDataFiles{
 	public const ENTITY_IDENTIFIERS_NBT = BEDROCK_DATA_PATH . '/entity_identifiers.nbt';
 	public const ENUMS = BEDROCK_DATA_PATH . '/enums';
 	public const ENUMS_PY = BEDROCK_DATA_PATH . '/enums.py';
-	public const ITEM_REGISTRY_JSON = BEDROCK_DATA_PATH . '/item_registry.json';
 	public const ITEM_TAGS_JSON = BEDROCK_DATA_PATH . '/item_tags.json';
 	public const LEVEL_SOUND_ID_MAP_JSON = BEDROCK_DATA_PATH . '/level_sound_id_map.json';
 	public const PROTOCOL_INFO_JSON = BEDROCK_DATA_PATH . '/protocol_info.json';

--- a/generated/data/bedrock/BiomeIds.php
+++ b/generated/data/bedrock/BiomeIds.php
@@ -123,4 +123,5 @@ final class BiomeIds{
 	public const MANGROVE_SWAMP = 191;
 	public const CHERRY_GROVE = 192;
 	public const PALE_GARDEN = 193;
+	public const SULFUR_CAVES = 194;
 }

--- a/generated/data/bedrock/block/BlockStateNames.php
+++ b/generated/data/bedrock/block/BlockStateNames.php
@@ -108,6 +108,7 @@ final class BlockStateNames{
 	public const PERSISTENT_BIT = "persistent_bit";
 	public const PILLAR_AXIS = "pillar_axis";
 	public const PORTAL_AXIS = "portal_axis";
+	public const POTENT_SULFUR_STATE = "potent_sulfur_state";
 	public const POWERED_BIT = "powered_bit";
 	public const POWERED_SHELF_TYPE = "powered_shelf_type";
 	public const PROPAGULE_STAGE = "propagule_stage";

--- a/generated/data/bedrock/block/BlockStateStringValues.php
+++ b/generated/data/bedrock/block/BlockStateStringValues.php
@@ -134,6 +134,12 @@ final class BlockStateStringValues{
 	public const PORTAL_AXIS_X = "x";
 	public const PORTAL_AXIS_Z = "z";
 
+	public const POTENT_SULFUR_STATE_CONTINUOUS = "continuous";
+	public const POTENT_SULFUR_STATE_DORMANT = "dormant";
+	public const POTENT_SULFUR_STATE_DRY = "dry";
+	public const POTENT_SULFUR_STATE_ERUPTING = "erupting";
+	public const POTENT_SULFUR_STATE_WET = "wet";
+
 	public const SEA_GRASS_TYPE_DEFAULT = "default";
 	public const SEA_GRASS_TYPE_DOUBLE_BOT = "double_bot";
 	public const SEA_GRASS_TYPE_DOUBLE_TOP = "double_top";

--- a/generated/data/bedrock/block/BlockTypeNames.php
+++ b/generated/data/bedrock/block/BlockTypeNames.php
@@ -1203,6 +1203,7 @@ final class BlockTypeNames{
 	public const SULFUR_BRICKS = "minecraft:sulfur_bricks";
 	public const SULFUR_DOUBLE_SLAB = "minecraft:sulfur_double_slab";
 	public const SULFUR_SLAB = "minecraft:sulfur_slab";
+	public const SULFUR_SPIKE = "minecraft:sulfur_spike";
 	public const SULFUR_STAIRS = "minecraft:sulfur_stairs";
 	public const SULFUR_WALL = "minecraft:sulfur_wall";
 	public const SUNFLOWER = "minecraft:sunflower";

--- a/generated/data/bedrock/item/ItemTypeNames.php
+++ b/generated/data/bedrock/item/ItemTypeNames.php
@@ -387,6 +387,7 @@ final class ItemTypeNames{
 	public const MUSIC_DISC_13 = "minecraft:music_disc_13";
 	public const MUSIC_DISC_5 = "minecraft:music_disc_5";
 	public const MUSIC_DISC_BLOCKS = "minecraft:music_disc_blocks";
+	public const MUSIC_DISC_BOUNCE = "minecraft:music_disc_bounce";
 	public const MUSIC_DISC_CAT = "minecraft:music_disc_cat";
 	public const MUSIC_DISC_CHIRP = "minecraft:music_disc_chirp";
 	public const MUSIC_DISC_CREATOR = "minecraft:music_disc_creator";

--- a/src/block/utils/RecordType.php
+++ b/src/block/utils/RecordType.php
@@ -110,7 +110,7 @@ enum RecordType{
 		return $this->getMetadata()[0];
 	}
 
-	public function getSoundId() : int{
+	public function getSoundId() : string{
 		return $this->getMetadata()[1];
 	}
 

--- a/src/network/mcpe/handler/PreSpawnPacketHandler.php
+++ b/src/network/mcpe/handler/PreSpawnPacketHandler.php
@@ -113,7 +113,8 @@ class PreSpawnPacketHandler extends PacketHandler{
 				false,
 				false,
 				new NetworkPermissions(disableClientSounds: true),
-				null,
+				false, //isLoggingChat
+				null, //serverJoinInformation
 				new ServerTelemetryData("", "", "", ""),
 				[],
 				0,

--- a/src/world/sound/RecordStopSound.php
+++ b/src/world/sound/RecordStopSound.php
@@ -30,6 +30,6 @@ use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
 class RecordStopSound implements Sound{
 
 	public function encode(Vector3 $pos) : array{
-		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::STOP_RECORD, $pos, false)];
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::RECORD_NULL, $pos, false)];
 	}
 }


### PR DESCRIPTION
Bump BedrockProtocol/BedrockData to bedrock-1.26.30 (protocol 975 -> 1001, v26.20 -> v26.30). Stable refs: protocol pinned to commit 507a8df, data sourced from the Plutonium-Mcpe/BedrockData fork. item-upgrade-schema -> 1.17.0.

Regenerate codegen (new: sulfur_spike block, music_disc_bounce item, sulfur_caves biome).

API breaks fixed:
- StartGamePacket::create() new isLoggingChat parameter
- RecordType::getSoundId() now returns string (sound ids became strings)
- RecordStopSound: LevelSoundEvent::STOP_RECORD removed -> RECORD_NULL

<!-- Summarize your PR here. Keep it short and simple. -->
<!-- Explain existing problems or why this pull request is necessary -->

<!-- DO NOT submit AI generated code or use AI to generate PR descriptions. -->
<!-- These are a waste of our team's time and your PR will be closed immediately. -->

### Related issues & PRs
<!--
* Fixes #1
* Related to #2
-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
<!-- If not, you can delete this section -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
<!-- If not, you can delete this section -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
<!-- If not, you can delete this section -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!-- For example, future changes that this PR lays the groundwork for -->

## Tests
<!--
If this PR affects gameplay or user experience in some way, it must be manually tested.
Include any screenshots or videos of manual testing here.
Any test plugin code should also be pasted here if it can't be adapted to a PHPUnit test.
-->
